### PR TITLE
Fikset dobbel autentisering av token med obo-middleware

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
   test-build-and-push:
     name: Build and push
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/fix-dobbel-middleware-autentisering'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
       - name: Run tests
         run: npm test
       - name: Create image tag
-        run: echo "IMAGE_TAG=$(TZ=\"Europe/Oslo\" date +%Y.%m.%d_%H.%M)-$(git rev-parse --short=12 HEAD)" >> $GITHUB_ENV
+        run: echo "IMAGE_TAG=DEBUG-$(TZ=\"Europe/Oslo\" date +%Y.%m.%d_%H.%M)-$(git rev-parse --short=12 HEAD)" >> $GITHUB_ENV
       - name: Build and push Docker image
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/server.ts
+++ b/src/server.ts
@@ -81,7 +81,7 @@ async function startServer() {
 			proxy.proxies.forEach(p => {
 				const proxyFrom = routeUrl(p.fromPath);
 
-				app.use(
+				app.all(
 					proxyFrom,
 					oboMiddleware({ authConfig: auth, proxy: p, oboTokenStore, oboTokenClient, tokenValidator }),
 					proxyMiddleware(proxyFrom, p)


### PR DESCRIPTION
Hvis man har flere proxy middlewares som blir truffet av samme request så vil tokenet bli autentisert og utvekslet flere ganger som ikke blir riktig. Bruk heller ruter som stopper request istedenfor å sende videre til neste middleware.