### PR TITLE
downgrade helmet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "compression": "^1.7.4",
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "helmet": "^6.0.1",
+        "helmet": "^4.6.0",
         "http-proxy-middleware": "^2.0.6",
         "jsdom": "^21.1.0",
         "jsonwebtoken": "^9.0.0",
@@ -3491,11 +3491,11 @@
       }
     },
     "node_modules/helmet": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-6.0.1.tgz",
-      "integrity": "sha512-8wo+VdQhTMVBMCITYZaGTbE4lvlthelPYSvoyNvk4RECTmrVjMerp9RfUOQXZWLvCcAn1pKj7ZRxK4lI9Alrcw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
+      "integrity": "sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg==",
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/html-dom-parser": {
@@ -9376,9 +9376,9 @@
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
     "helmet": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-6.0.1.tgz",
-      "integrity": "sha512-8wo+VdQhTMVBMCITYZaGTbE4lvlthelPYSvoyNvk4RECTmrVjMerp9RfUOQXZWLvCcAn1pKj7ZRxK4lI9Alrcw=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz",
+      "integrity": "sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg=="
     },
     "html-dom-parser": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "helmet": "^6.0.1",
+    "helmet": "^4.6.0",
     "http-proxy-middleware": "^2.0.6",
     "jsdom": "^21.1.0",
     "jsonwebtoken": "^9.0.0",


### PR DESCRIPTION
`helmet` endret default verdi for [cross origin embedder policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy) i versjon 5 som førte til issues med lasting av css-filer i et microfrontend-oppsett (veilarbpersonflate).

Dette kunne antagelig blitt løst ved å sette `crossOriginEmbedderPolicy: false` i `helmet-middleware.ts` i stedet for å nedgradere, men skyver på å gjøre dette til neste metateam-møte i stedet.