### PR TITLE
Remove proxy middleware filter

### DIFF
--- a/src/middleware/proxy-middleware.ts
+++ b/src/middleware/proxy-middleware.ts
@@ -6,7 +6,7 @@ import { CALL_ID, CONSUMER_ID } from "./tracingMiddleware.js";
 import { APP_NAME } from "../config/base-config.js";
 
 export const proxyMiddleware = (proxyContextPath: string, proxy: Proxy): RequestHandler => {
-	return createProxyMiddleware(proxyContextPath, {
+	return createProxyMiddleware({
 		target: proxy.toUrl,
 		logLevel: 'error',
 		headers: {


### PR DESCRIPTION
http-proxy-middleware sitt filter fucker med forsøket mitt på å matche på regex fordi den bruker en annen logikk enn express sine routes. Fordi proxy-middleware kun brukes inni en `app.use(filter, proxyMiddleware())` så er filtreringen i http-proxy-middleware redundant, så jeg er temmelig sikker på at den bare kan fjernes uten problem.