### PR TITLE
Add a filter to compression to ignore SSE

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -37,7 +37,15 @@ async function startServer() {
 
 	const routeUrl = (path: string): string => urlJoin(base.contextPath, path)
 
-	app.use(compression())
+	app.use(compression({
+    filter: (req: express.Request, res: express.Response) => {
+      // Don't compress server sent events.
+      if (req.headers["accept"] === "text/event-stream") {
+        return false;
+      }
+      return compression.filter(req, res);
+    },
+  }));
 
 	if (cors.origin) {
 		app.use(corsMiddleware({


### PR DESCRIPTION
Server sent events (SSE) don't play nicely with compression. This commit adds a filter which disables compression for all SSE requests (requests with `Accept: text/event-stream`).