### PR TITLE
Fjern cross-env-pakke med sårbarhet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "@types/jsonwebtoken": "9.0.7",
         "@types/mime-types": "2.1.4",
         "@types/node": "22.10.5",
-        "cross-env": "7.0.3",
         "dotenv-cli": "7.4.3",
         "jest": "29.7.0",
         "ts-jest": "29.2.5",
@@ -2322,24 +2321,6 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
-    },
-    "node_modules/cross-env": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "bin": {
-        "cross-env": "src/bin/cross-env.js",
-        "cross-env-shell": "src/bin/cross-env-shell.js"
-      },
-      "engines": {
-        "node": ">=10.14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@types/jsonwebtoken": "9.0.7",
     "@types/mime-types": "2.1.4",
     "@types/node": "22.10.5",
-    "cross-env": "7.0.3",
     "dotenv-cli": "7.4.3",
     "jest": "29.7.0",
     "ts-jest": "29.2.5",


### PR DESCRIPTION
Tror ikke `cross-env` har vært i bruk siden 2020, før [denne commiten](https://github.com/navikt/poao-frontend/commit/d6b57f248c4623a99715f5462172816c9c84906c). `cross-env` er heller ikke [oppdatert siden 2020](https://github.com/kentcdodds/cross-env) og har en [sårbarhet](https://salsa.nav.cloud.nais.io/vulnerabilities/GITHUB/GHSA-3xgq-45jj-v275) i sin `cross-spawn`-avhengighet.