### PR TITLE
Feature/token cache

### DIFF
--- a/src/config/auth-config.ts
+++ b/src/config/auth-config.ts
@@ -112,11 +112,11 @@ const resolveValkeyConfig = (valkeyConfig: JsonConfig.AuthConfig['tokenCacheConf
 
 	const redisInstanceName = valkeyConfig.valkeyInstanceName.toLocaleUpperCase();
 
-	const uri	 = assert(process.env['VALKEY_URI_' + redisInstanceName]) // The URI for the instance
-	const host	 = assert(process.env['VALKEY_HOST_' + redisInstanceName]) // The host for the instance
-	const port	 = assert(process.env['VALKEY_PORT_' + redisInstanceName]) // The port for the instance
-	const username	 = assert(process.env['VALKEY_USERNAME_' + redisInstanceName]) // The username to use when connecting.
-	const password	 = assert(process.env['VALKEY_PASSWORD_' + redisInstanceName]) // The password to use when connecting.
+	const uri = assert(process.env['VALKEY_URI_' + redisInstanceName]) // The URI for the instance
+	const host = assert(process.env['VALKEY_HOST_' + redisInstanceName]) // The host for the instance
+	const port = assert(process.env['VALKEY_PORT_' + redisInstanceName]) // The port for the instance
+	const username = assert(process.env['VALKEY_USERNAME_' + redisInstanceName]) // The username to use when connecting.
+	const password = assert(process.env['VALKEY_PASSWORD_' + redisInstanceName]) // The password to use when connecting.
 
 	return {
 		uri,

--- a/src/middleware/obo-middleware.ts
+++ b/src/middleware/obo-middleware.ts
@@ -1,22 +1,21 @@
-import { asyncMiddleware } from '../utils/express-utils.js';
-import { logger } from '../utils/logger.js';
+import { Request } from "express";
+import { BaseClient, Client } from 'openid-client';
+import { AuthConfig, OboProviderType } from '../config/auth-config.js';
+import { Proxy } from '../config/proxy-config.js';
+import { createAzureAdOnBehalfOfToken, createTokenXOnBehalfOfToken } from '../utils/auth/auth-client-utils.js';
+import { createAzureAdScope, createTokenXScope } from '../utils/auth/auth-config-utils.js';
 import {
 	AUTHORIZATION_HEADER,
 	getAccessToken,
 	getExpiresInSecondWithClockSkew,
-	getTokenSubject,
 	WONDERWALL_ID_TOKEN_HEADER
 } from '../utils/auth/auth-token-utils.js';
-import { createAzureAdOnBehalfOfToken, createTokenXOnBehalfOfToken } from '../utils/auth/auth-client-utils.js';
-import { getSecondsUntil } from '../utils/date-utils.js';
-import { AuthConfig, OboProviderType } from '../config/auth-config.js';
-import { Proxy } from '../config/proxy-config.js';
-import { BaseClient, Client } from 'openid-client';
 import { TokenValidator } from '../utils/auth/token-validator.js';
-import { createAzureAdScope, createTokenXScope } from '../utils/auth/auth-config-utils.js';
-import { Request } from "express";
+import { createOboTokenKey, OboTokenStore } from "../utils/auth/tokenStore/token-store.js";
+import { getSecondsUntil } from '../utils/date-utils.js';
+import { asyncMiddleware } from '../utils/express-utils.js';
+import { logger } from '../utils/logger.js';
 import { CALL_ID, CONSUMER_ID } from "./tracingMiddleware.js";
-import { OboTokenStore } from "../utils/auth/tokenStore/token-store.js";
 
 interface ProxyOboMiddlewareParams {
 	authConfig: AuthConfig;
@@ -59,13 +58,9 @@ export const setOBOTokenOnRequest = async (req: Request, tokenValidator: TokenVa
 		return;
 	}
 
-	const tokenSubject = getTokenSubject(accessToken);
-	if (!tokenSubject) {
-		logger.error({ message: 'Unable to get subject from token', callId: req.headers[CALL_ID], consumerId: req.headers[CONSUMER_ID] });
-		return { status: 401 }
-	}
+	const oboTokenKey = createOboTokenKey(accessToken, scope)
 
-	let oboToken = await oboTokenStore.getUserOboToken(tokenSubject, scope);
+	let oboToken = await oboTokenStore.getUserOboToken(oboTokenKey);
 	if (!oboToken) {
 		const now = new Date().getTime()
 
@@ -84,7 +79,7 @@ export const setOBOTokenOnRequest = async (req: Request, tokenValidator: TokenVa
 		const expiresInSeconds = getSecondsUntil(oboToken.expiresAt * 1000);
 		const expiresInSecondWithClockSkew = getExpiresInSecondWithClockSkew(expiresInSeconds);
 
-		await oboTokenStore.setUserOboToken(tokenSubject, scope, expiresInSecondWithClockSkew, oboToken);
+		await oboTokenStore.setUserOboToken(oboTokenKey, expiresInSecondWithClockSkew, oboToken);
 	} else {
 		logger.info({
 			message: `On-behalf-of fetched from ${oboTokenStore.cacheType} cache`,

--- a/src/middleware/obo-middleware.ts
+++ b/src/middleware/obo-middleware.ts
@@ -16,7 +16,7 @@ import { TokenValidator } from '../utils/auth/token-validator.js';
 import { createAzureAdScope, createTokenXScope } from '../utils/auth/auth-config-utils.js';
 import { Request } from "express";
 import { CALL_ID, CONSUMER_ID } from "./tracingMiddleware.js";
-import {OboTokenStore} from "../utils/auth/tokenStore/token-store.js";
+import { OboTokenStore } from "../utils/auth/tokenStore/token-store.js";
 
 interface ProxyOboMiddlewareParams {
 	authConfig: AuthConfig;

--- a/src/middleware/proxy-middleware.ts
+++ b/src/middleware/proxy-middleware.ts
@@ -4,11 +4,11 @@ import { logger } from '../utils/logger.js';
 import { Proxy } from '../config/proxy-config.js';
 import { CALL_ID, CONSUMER_ID } from "./tracingMiddleware.js";
 import { APP_NAME } from "../config/base-config.js";
-import {normalizePathParams} from "../utils/logger.js";
+import { normalizePathParams } from "../utils/logger.js";
 
 export const proxyMiddleware = (proxyContextPath: string, proxy: Proxy): RequestHandler => {
 	return createProxyMiddleware({
-		target: `${proxy.toUrl}${proxy.preserveFromPath ? proxyContextPath : ''}` ,
+		target: `${proxy.toUrl}${proxy.preserveFromPath ? proxyContextPath : ''}`,
 		headers: {
 			[CONSUMER_ID]: APP_NAME,
 		},

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ import { oboMiddleware } from './middleware/obo-middleware.js';
 import { authInfoRoute } from './route/auth-info-route.js';
 import { proxyMiddleware } from './middleware/proxy-middleware.js';
 import { tracingMiddleware } from "./middleware/tracingMiddleware.js";
-import {createTokenStore} from "./utils/auth/tokenStore/token-store.js";
+import { createTokenStore } from "./utils/auth/tokenStore/token-store.js";
 
 const app: express.Application = express();
 
@@ -38,14 +38,14 @@ async function startServer() {
 	const routeUrl = (path: string): string => urlJoin(base.contextPath, path)
 
 	app.use(compression({
-    filter: (req: express.Request, res: express.Response) => {
-      // Don't compress server sent events.
-      if (req.headers["accept"] === "text/event-stream") {
-        return false;
-      }
-      return compression.filter(req, res);
-    },
-  }));
+		filter: (req: express.Request, res: express.Response) => {
+			// Don't compress server sent events.
+			if (req.headers["accept"] === "text/event-stream") {
+				return false;
+			}
+			return compression.filter(req, res);
+		},
+	}));
 
 	if (cors.origin) {
 		app.use(corsMiddleware({

--- a/src/utils/auth/auth-token-utils.ts
+++ b/src/utils/auth/auth-token-utils.ts
@@ -52,7 +52,3 @@ export function extractTokenPayload(jwtToken: string): JsonData {
 		throw e;
 	}
 }
-
-export function getTokenSubject(jwtToken: string): string | undefined {
-	return extractTokenPayload(jwtToken).sub;
-}

--- a/src/utils/auth/tokenStore/in-memory-token-store.ts
+++ b/src/utils/auth/tokenStore/in-memory-token-store.ts
@@ -1,12 +1,8 @@
-import {OboToken} from '../auth-token-utils.js';
 import NodeCache from 'node-cache';
-import {minutesToSeconds} from '../../utils.js';
-import {logger} from "../../logger.js";
-import {OboTokenStore} from "./token-store.js";
-
-function createOboTokenKey(userId: string, appIdentifier: string): string {
-	return `${userId}_${appIdentifier}`;
-}
+import { logger } from "../../logger.js";
+import { minutesToSeconds } from '../../utils.js';
+import { OboToken } from '../auth-token-utils.js';
+import { createOboTokenKey, OboTokenStore } from "./token-store.js";
 
 export const createInMemoryCache = (): OboTokenStore => {
 	const cache = new NodeCache({

--- a/src/utils/auth/tokenStore/in-memory-token-store.ts
+++ b/src/utils/auth/tokenStore/in-memory-token-store.ts
@@ -2,7 +2,7 @@ import NodeCache from 'node-cache';
 import { logger } from "../../logger.js";
 import { minutesToSeconds } from '../../utils.js';
 import { OboToken } from '../auth-token-utils.js';
-import { createOboTokenKey, OboTokenStore } from "./token-store.js";
+import { OboTokenStore, OboTokenKey } from "./token-store.js";
 
 export const createInMemoryCache = (): OboTokenStore => {
 	const cache = new NodeCache({
@@ -10,24 +10,24 @@ export const createInMemoryCache = (): OboTokenStore => {
 	});
 
 	return {
-		getUserOboToken: async (userId: string, appIdentifier: string): Promise<OboToken | undefined> => {
+		getUserOboToken: async (key: OboTokenKey): Promise<OboToken | undefined> => {
 			try {
-				return cache.get(createOboTokenKey(userId, appIdentifier))
+				return cache.get(key)
 			} catch (e) {
 				logger.warn("Failed to get OboToken from in-memory cache", e)
 				return undefined
 			}
 		},
-		setUserOboToken: async (userId: string, appIdentifier: string, expiresInSeconds: number, oboToken: OboToken) => {
+		setUserOboToken: async (key: OboTokenKey, expiresInSeconds: number, oboToken: OboToken) => {
 			try {
-				cache.set(createOboTokenKey(userId, appIdentifier), oboToken, expiresInSeconds)
+				cache.set(key, oboToken, expiresInSeconds)
 			} catch (e) {
 				logger.warn("Failed to set OboToken in in-memory cache", e)
 			}
 		},
-		deleteUserOboToken: async (userId: string, appIdentifier: string) => {
+		deleteUserOboToken: async (key: OboTokenKey) => {
 			try {
-				cache.del(createOboTokenKey(userId, appIdentifier))
+				cache.del(key)
 			} catch (e) {
 				logger.warn("Failed to delete OboToken from in-memory cache", e)
 			}

--- a/src/utils/auth/tokenStore/token-store.ts
+++ b/src/utils/auth/tokenStore/token-store.ts
@@ -1,7 +1,15 @@
+import crypto from "crypto";
 import { ValkeyConfig } from "../../../config/auth-config.js";
 import { OboToken } from "../auth-token-utils.js";
-import { createValkeyCache } from "./valkey-token-store.js";
 import { createInMemoryCache } from "./in-memory-token-store.js";
+import { createValkeyCache } from "./valkey-token-store.js";
+
+export type OboTokenKey = `${string}_${string}`;
+
+export function createOboTokenKey(token: string, appIdentifier: string): OboTokenKey {
+    const tokenHash = crypto.createHash('sha256').update(token, 'utf8').digest('hex');
+    return `${tokenHash}_${appIdentifier}`;
+}
 
 export function createTokenStore(valkeyConfig: ValkeyConfig | undefined): OboTokenStore {
     if (valkeyConfig) {
@@ -11,14 +19,10 @@ export function createTokenStore(valkeyConfig: ValkeyConfig | undefined): OboTok
     }
 }
 
-export function createOboTokenKey(userId: string, appIdentifier: string): string {
-    return `${userId}_${appIdentifier}`;
-}
-
 export interface OboTokenStore {
-    getUserOboToken: (userId: string, appIdentifier: string) => Promise<OboToken | undefined>;
-    setUserOboToken: (userId: string, appIdentifier: string, expiresInSeconds: number, oboToken: OboToken) => Promise<void>;
-    deleteUserOboToken: (userId: string, appIdentifier: string) => Promise<void>;
+    getUserOboToken: (key: OboTokenKey) => Promise<OboToken | undefined>;
+    setUserOboToken: (key: OboTokenKey, expiresInSeconds: number, oboToken: OboToken) => Promise<void>;
+    deleteUserOboToken: (key: OboTokenKey) => Promise<void>;
     close: () => Promise<void>;
     cacheType: 'in-memory' | 'valkey';
 }

--- a/src/utils/auth/tokenStore/token-store.ts
+++ b/src/utils/auth/tokenStore/token-store.ts
@@ -1,7 +1,7 @@
-import {ValkeyConfig} from "../../../config/auth-config.js";
-import {OboToken} from "../auth-token-utils.js";
-import {createValkeyCache} from "./valkey-token-store.js";
-import {createInMemoryCache} from "./in-memory-token-store.js";
+import { ValkeyConfig } from "../../../config/auth-config.js";
+import { OboToken } from "../auth-token-utils.js";
+import { createValkeyCache } from "./valkey-token-store.js";
+import { createInMemoryCache } from "./in-memory-token-store.js";
 
 export function createTokenStore(valkeyConfig: ValkeyConfig | undefined): OboTokenStore {
     if (valkeyConfig) {
@@ -11,7 +11,7 @@ export function createTokenStore(valkeyConfig: ValkeyConfig | undefined): OboTok
     }
 }
 
-export  function createOboTokenKey(userId: string, appIdentifier: string): string {
+export function createOboTokenKey(userId: string, appIdentifier: string): string {
     return `${userId}_${appIdentifier}`;
 }
 

--- a/src/utils/auth/tokenStore/valkey-token-store.ts
+++ b/src/utils/auth/tokenStore/valkey-token-store.ts
@@ -1,8 +1,8 @@
-import {ValkeyConfig} from "../../../config/auth-config.js";
-import {Redis, RedisOptions} from "iovalkey";
-import {OboToken} from "../auth-token-utils.js";
-import {logger} from "../../logger.js";
-import {createOboTokenKey, OboTokenStore} from "./token-store.js";
+import { ValkeyConfig } from "../../../config/auth-config.js";
+import { Redis, RedisOptions } from "iovalkey";
+import { OboToken } from "../auth-token-utils.js";
+import { logger } from "../../logger.js";
+import { createOboTokenKey, OboTokenStore } from "./token-store.js";
 
 export const configureValkey = (valkeyConfig: ValkeyConfig) => {
     const options: RedisOptions = {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -29,7 +29,7 @@ const maskedJsonFormat = format.printf((logEntry) => {
 	return jsonLog.replace(/(?<!\w|-)\d{11}(?!\w|-)/g, '<fnr>')
 });
 
-export function normalizePathParams(path: string) : string {
+export function normalizePathParams(path: string): string {
 	return path
 		.replace(/((?<!\w|-)\d+(?!\w|-))/g, '<id>')  // numerid id in path
 		.replace(/[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}/g, '<uuid>') // uuid in path

--- a/src/utils/modiacontextholder/setModiaContext.ts
+++ b/src/utils/modiacontextholder/setModiaContext.ts
@@ -9,7 +9,7 @@ import { JsonConfig } from "../../config/app-config-resolver.js";
 import { AUTHORIZATION_HEADER } from "../auth/auth-token-utils.js";
 import { CALL_ID, CONSUMER_ID } from "../../middleware/tracingMiddleware.js";
 import { APP_NAME } from "../../config/base-config.js";
-import {createTokenStore} from "../auth/tokenStore/token-store.js";
+import { createTokenStore } from "../auth/tokenStore/token-store.js";
 
 const createModiacontextHolderConfig = async () => {
     const azureAdProvider = resolveAzureAdProvider()


### PR DESCRIPTION
Benytter `sid` i stedet for `sub` som del av token cache key. Dette gjør at oboMiddleware også vil hente nye tokens når den ansatte får en ny jwt session.

En måte å få ny session på kan være at ansatt logger seg av SSO og inn igjen. Denne mekanismen kan vi benytte til å bl.a.
trigge henting av oppdaterte claims ifm. tilgangskontroll uten å måtte vente oppmot en time på at token blir utdatert og at oboMiddleware henter nytt token med oppdatert claims.